### PR TITLE
httpclient 4.5 libraries collide with httpclient 4.2 on jenkins.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,18 +143,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.5</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
       <artifactId>fluent-hc</artifactId>
-      <version>4.5</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpcore</artifactId>
-      <version>4.4.1</version>
+      <version>4.2.1</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>


### PR DESCRIPTION
fixes broken jira release functions, e.g., ERROR: Publisher 'Create JIRA
version' aborted due to exception: 
java.lang.NoSuchFieldError: INSTANCE
    at
org.apache.http.conn.ssl.SSLConnectionSocketFactory.<clinit>(SSLConnectionSocketFactory.java:144)

fixed by removing explicit references to httpclient and backed fluent-hc to 4.2.1